### PR TITLE
Replace Google Fonts with self-hosted fonts for privacy

### DIFF
--- a/website/app/components/Layout.tsx
+++ b/website/app/components/Layout.tsx
@@ -39,6 +39,7 @@ export default function Layout({ copyrightYear, children }: LayoutProps) {
                 fontWeight: "700",
                 color: "#1a1a1a",
                 textDecoration: "none",
+                fontFamily: "'Delius', system-ui, sans-serif",
               }}
             >
               Señor Mano

--- a/website/app/root.tsx
+++ b/website/app/root.tsx
@@ -7,19 +7,10 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
+import "@fontsource/delius";
+import "@fontsource/lato";
 
-export const links: LinksFunction = () => [
-  { rel: "preconnect", href: "https://fonts.googleapis.com" },
-  {
-    rel: "preconnect",
-    href: "https://fonts.gstatic.com",
-    crossOrigin: "anonymous",
-  },
-  {
-    rel: "stylesheet",
-    href: "https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap",
-  },
-];
+export const links: LinksFunction = () => [];
 
 export default function App() {
   return (
@@ -41,7 +32,7 @@ export default function App() {
           boxSizing: "border-box",
           lineHeight: 1.6,
           WebkitFontSmoothing: "antialiased",
-          fontFamily: "'Inter', system-ui, sans-serif",
+          fontFamily: "'Lato', system-ui, -apple-system, sans-serif",
           backgroundColor: "#aadfeb",
           color: "#1a1a1a",
         }}

--- a/website/app/routes/_index.tsx
+++ b/website/app/routes/_index.tsx
@@ -69,6 +69,7 @@ export default function Index() {
             fontWeight: "800",
             marginBottom: "1rem",
             color: "#1a1a1a",
+            fontFamily: "'Delius', system-ui, sans-serif",
           }}
         >
           Señor Mano te enseña castellano
@@ -129,6 +130,7 @@ export default function Index() {
             textAlign: "center",
             marginBottom: "2rem",
             color: "#1a1a1a",
+            fontFamily: "'Delius', system-ui, sans-serif",
           }}
         >
           Descargar cuadernillos
@@ -166,6 +168,7 @@ export default function Index() {
                       fontSize: "1.5rem",
                       fontWeight: "700",
                       marginBottom: "0.5rem",
+                      fontFamily: "'Delius', system-ui, sans-serif",
                     }}
                   >
                     Unidad {unit.number}: {unit.title}

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@fontsource/delius": "^5.2.6",
+    "@fontsource/lato": "^5.2.6",
     "@remix-run/node": "^2.8.1",
     "@remix-run/react": "^2.8.1",
     "@remix-run/serve": "^2.8.1",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -5,6 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@fontsource/delius':
+    specifier: ^5.2.6
+    version: 5.2.6
+  '@fontsource/lato':
+    specifier: ^5.2.6
+    version: 5.2.6
   '@remix-run/node':
     specifier: ^2.8.1
     version: 2.16.8(typescript@5.8.3)
@@ -841,6 +847,14 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
+
+  /@fontsource/delius@5.2.6:
+    resolution: {integrity: sha512-EDiWqw+TsoT3PESH4aWEqu3FB72tsgyqAlULwNmSBZ72rnW/F2HU9RubLE4zoTClvfUOiduGDsjenV0T4iAQFA==}
+    dev: false
+
+  /@fontsource/lato@5.2.6:
+    resolution: {integrity: sha512-ykbyuHKHdFsV8QNWPgo2kkCV0veY8/w1HzPlTd7f08LRGGYijPoN7QHkVKPq5QLpgeNauPPe+0a6oRhd8b6MpQ==}
+    dev: false
 
   /@humanwhocodes/config-array@0.13.0:
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}


### PR DESCRIPTION
## Summary
- Replace Google Fonts with self-hosted @fontsource packages to eliminate third-party tracking
- Apply Delius font to all headings and branding elements for consistent visual identity
- Use Lato as body font for excellent readability and warm feel that complements Delius

## Changes Made
- Installed @fontsource/delius and @fontsource/lato packages
- Removed Google Fonts links from root.tsx
- Applied Delius font to h1, h2, h3 headings in _index.tsx
- Applied Delius font to "Señor Mano" header text in Layout.tsx
- Set Lato as default body font in root.tsx

## Benefits
- Improved user privacy (no data sent to Google)
- Eliminated external font dependencies
- Maintained excellent typography with complementary fonts
- Better performance with self-hosted fonts

Close #17