### PR TITLE
Simplify PDF generation script and remove command-line options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,9 +150,9 @@ This ensures:
 ./generate_pdfs.sh
 ```
 
-This generates all cuadernillos in both Japanese and English to verify the complete system works properly.
+This generates all cuadernillos in both Japanese and English, all units (present-tense, past-tense), and updates website preview data to verify the complete system works properly.
 
-**Exception:** When actively developing/debugging the generation scripts themselves, you may test with a single cuadernillo (e.g., `./generate_pdfs.sh 1 -l japanese`) for faster iteration, but always run the full test before completing your work.
+**Note:** The script always generates everything - there are no more command-line options for specific cuadernillos or languages. This ensures consistency and that all content stays in sync.
 
 **PDF Page Verification:**
 After generating PDFs, always verify that each PDF has exactly 6 pages (one per exercise type). Use this command to check page counts:

--- a/PDF_GENERATION.md
+++ b/PDF_GENERATION.md
@@ -4,23 +4,23 @@ The PDF generation tools are located in `ejercicios-src/scripts/` and convert th
 
 ## Quick Start
 
-### Option 1: Automated Setup and Generation (using root wrapper)
+### Option 1: Simple Generation (Recommended)
 ```bash
-# Generate all cuadernillos for both languages (runs setup automatically)
+# Generate all cuadernillos for all units in both languages
+# Also updates website preview data
 ./generate_pdfs.sh
-
-# Generate specific cuadernillo for both languages
-./generate_pdfs.sh 1    # Cuadernillo 1 only
-./generate_pdfs.sh 2    # Cuadernillo 2 only
-./generate_pdfs.sh 3    # Cuadernillo 3 only
-
-# Generate for specific language
-./generate_pdfs.sh -l japanese    # All cuadernillos in Japanese
-./generate_pdfs.sh -l english     # All cuadernillos in English
-./generate_pdfs.sh 1 -l english   # Cuadernillo 1 in English only
 ```
 
-### Option 2: Direct Script Usage
+This single command will:
+- Generate all cuadernillos (1-4) 
+- Generate all units (present-tense, past-tense)
+- Generate both languages (Japanese and English)
+- Update website preview data
+- Verify all PDFs have exactly 6 pages
+
+### Option 2: Advanced Usage (For Development)
+If you need to generate specific combinations for testing:
+
 ```bash
 # Navigate to scripts directory
 cd ejercicios-src/scripts
@@ -28,26 +28,12 @@ cd ejercicios-src/scripts
 # Run setup once (uses Python 3.12 by default)
 ./setup.sh
 
-# Or specify a different Python version
-PYTHON_VERSION=python3.11 ./setup.sh
-
-# Then generate PDFs
+# Generate specific combinations
 source ../../venv/bin/activate
-python generate_pdf.py        # All cuadernillos in Japanese (default)
-python generate_pdf.py english # All cuadernillos in English
-python generate_pdf.py 1      # Cuadernillo 1 in Japanese only
-python generate_pdf.py 1 english # Cuadernillo 1 in English only
-deactivate
-```
-
-### Option 3: Use specific Python version directly
-```bash
-# Navigate to scripts directory and create venv with specific Python version
-cd ejercicios-src/scripts
-/opt/homebrew/bin/python3.11 -m venv ../../venv
-source ../../venv/bin/activate
-pip install -r requirements.txt
-python generate_pdf.py
+python generate_pdf.py japanese all           # All Japanese cuadernillos
+python generate_pdf.py english all            # All English cuadernillos  
+python generate_pdf.py japanese present-tense # Japanese present tense only
+python generate_pdf.py english past-tense     # English past tense only
 deactivate
 ```
 
@@ -55,15 +41,28 @@ deactivate
 
 The scripts will generate PDFs in organized directories:
 
-### Japanese versions (default):
-- `website/public/pdfs/japanese/cuadernillo-1-ja.pdf` - First conjugation (-AR verbs)
-- `website/public/pdfs/japanese/cuadernillo-2-ja.pdf` - Second conjugation (-ER verbs)  
-- `website/public/pdfs/japanese/cuadernillo-3-ja.pdf` - Third conjugation (-IR verbs)
+### Japanese versions:
+- `website/public/pdfs/japanese/cuadernillo-1-present-tense-ja.pdf` - First conjugation (-AR verbs), present tense
+- `website/public/pdfs/japanese/cuadernillo-1-past-tense-ja.pdf` - First conjugation (-AR verbs), past tense
+- `website/public/pdfs/japanese/cuadernillo-2-present-tense-ja.pdf` - Second conjugation (-ER verbs), present tense
+- `website/public/pdfs/japanese/cuadernillo-2-past-tense-ja.pdf` - Second conjugation (-ER verbs), past tense
+- `website/public/pdfs/japanese/cuadernillo-3-present-tense-ja.pdf` - Third conjugation (-IR verbs), present tense
+- `website/public/pdfs/japanese/cuadernillo-3-past-tense-ja.pdf` - Third conjugation (-IR verbs), past tense
+- `website/public/pdfs/japanese/cuadernillo-4-present-tense-ja.pdf` - Mixed verbs, present tense
+- `website/public/pdfs/japanese/cuadernillo-4-past-tense-ja.pdf` - Mixed verbs, past tense
 
 ### English versions:
-- `website/public/pdfs/english/cuadernillo-1-en.pdf` - First conjugation (-AR verbs)
-- `website/public/pdfs/english/cuadernillo-2-en.pdf` - Second conjugation (-ER verbs)
-- `website/public/pdfs/english/cuadernillo-3-en.pdf` - Third conjugation (-IR verbs)
+- `website/public/pdfs/english/cuadernillo-1-present-tense-en.pdf` - First conjugation (-AR verbs), present tense
+- `website/public/pdfs/english/cuadernillo-1-past-tense-en.pdf` - First conjugation (-AR verbs), past tense
+- `website/public/pdfs/english/cuadernillo-2-present-tense-en.pdf` - Second conjugation (-ER verbs), present tense
+- `website/public/pdfs/english/cuadernillo-2-past-tense-en.pdf` - Second conjugation (-ER verbs), past tense
+- `website/public/pdfs/english/cuadernillo-3-present-tense-en.pdf` - Third conjugation (-IR verbs), present tense
+- `website/public/pdfs/english/cuadernillo-3-past-tense-en.pdf` - Third conjugation (-IR verbs), past tense
+- `website/public/pdfs/english/cuadernillo-4-present-tense-en.pdf` - Mixed verbs, present tense
+- `website/public/pdfs/english/cuadernillo-4-past-tense-en.pdf` - Mixed verbs, past tense
+
+### Website Preview Data:
+The script also updates `website/app/data/markdown/` with all exercise content for the web preview system.
 
 ## Features
 

--- a/ejercicios-src/scripts/generate_pdfs.sh
+++ b/ejercicios-src/scripts/generate_pdfs.sh
@@ -1,91 +1,8 @@
 #!/bin/bash
-# Wrapper script to generate PDFs with automatic virtual environment handling
-# Supports multilingual generation (Japanese and English versions)
+# Script to generate all PDF files from Spanish exercise markdown files
+# Always generates all cuadernillos for all units in both languages
 
 set -e
-
-# Parse command line arguments
-CUADERNILLO=""
-LANGUAGE=""
-UNIT=""
-HELP=false
-
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        -l|--language)
-            LANGUAGE="$2"
-            shift 2
-            ;;
-        -u|--unit)
-            UNIT="$2"
-            shift 2
-            ;;
-        -h|--help)
-            HELP=true
-            shift
-            ;;
-        [1-4])
-            CUADERNILLO="$1"
-            shift
-            ;;
-        *)
-            echo "Unknown option: $1"
-            exit 1
-            ;;
-    esac
-done
-
-if [[ "$HELP" == true ]]; then
-    echo "Usage: $0 [CUADERNILLO] [OPTIONS]"
-    echo ""
-    echo "Generate PDF files from Spanish exercise markdown files."
-    echo ""
-    echo "Arguments:"
-    echo "  CUADERNILLO       Cuadernillo number (1, 2, 3, or 4). If not specified, generates all cuadernillos."
-    echo ""
-    echo "Options:"
-    echo "  -l, --language    Language for instructions (japanese, english, or both)"
-    echo "                    Default: both (generates PDFs for both languages)"
-    echo "  -u, --unit        Grammar unit (present-tense, past-tense, or all)"
-    echo "                    Default: all (generates PDFs for all available units)"
-    echo "  -h, --help        Show this help message"
-    echo ""
-    echo "Examples:"
-    echo "  $0                          # Generate all available cuadernillos for all units in both languages"
-    echo "  $0 1                        # Generate cuadernillo 1 for all available units in both languages"
-    echo "  $0 2 -l japanese            # Generate cuadernillo 2 for all available units with Japanese instructions only"
-    echo "  $0 1 -u past-tense          # Generate cuadernillo 1 past-tense for both languages"
-    echo "  $0 1 -l english -u past-tense # Generate cuadernillo 1 past-tense with English instructions only"
-    echo ""
-    echo "Output files:"
-    echo "  Japanese: cuadernillo-1-ja.pdf, cuadernillo-2-ja.pdf, cuadernillo-3-ja.pdf, cuadernillo-4-ja.pdf"
-    echo "  English:  cuadernillo-1-en.pdf, cuadernillo-2-en.pdf, cuadernillo-3-en.pdf, cuadernillo-4-en.pdf"
-    exit 0
-fi
-
-# Set default language if not specified
-if [[ -z "$LANGUAGE" ]]; then
-    LANGUAGE="both"
-fi
-
-# Set default unit if not specified
-if [[ -z "$UNIT" ]]; then
-    UNIT="all"
-fi
-
-# Validate language option
-if [[ "$LANGUAGE" != "japanese" && "$LANGUAGE" != "english" && "$LANGUAGE" != "both" ]]; then
-    echo "Error: Language must be 'japanese', 'english', or 'both'"
-    echo "Use -h or --help for usage information"
-    exit 1
-fi
-
-# Validate unit option
-if [[ "$UNIT" != "present-tense" && "$UNIT" != "past-tense" && "$UNIT" != "all" ]]; then
-    echo "Error: Unit must be 'present-tense', 'past-tense', or 'all'"
-    echo "Use -h or --help for usage information"
-    exit 1
-fi
 
 # Check if virtual environment exists (look in project root)
 if [ ! -d "../../venv" ]; then
@@ -97,74 +14,32 @@ fi
 # Activate virtual environment from project root
 source ../../venv/bin/activate
 
-echo "🚀 Starting PDF generation..."
-echo "Language(s): $LANGUAGE"
-echo "Unit(s): $UNIT"
-
-if [[ -n "$CUADERNILLO" ]]; then
-    echo "Cuadernillo: $CUADERNILLO"
-else
-    echo "Cuadernillos: All (1, 2, 3, 4)"
-fi
-
+echo "🚀 Generating all PDF files..."
+echo "Cuadernillos: All (1, 2, 3, 4)"
+echo "Units: All (present-tense, past-tense)"
+echo "Languages: Both (Japanese, English)"
 echo ""
 
-# Generate function for a specific unit and language
-generate_for_unit_and_language() {
-    local unit="$1"
-    local language="$2"
-    
-    echo "📚 Generating $language $unit versions..."
-    if [[ -n "$CUADERNILLO" ]]; then
-        python generate_pdf.py "$CUADERNILLO" "$language" "$unit"
-    else
-        python generate_pdf.py "$language" "$unit"
-    fi
-    echo ""
-}
-
-# Generate PDFs based on unit and language selection
-if [[ "$UNIT" == "all" ]]; then
-    # Generate all available units
-    if [[ "$LANGUAGE" == "japanese" || "$LANGUAGE" == "both" ]]; then
-        if [[ -n "$CUADERNILLO" ]]; then
-            python generate_pdf.py "$CUADERNILLO" japanese all
-        else
-            python generate_pdf.py japanese all
-        fi
-        echo ""
-    fi
-    
-    if [[ "$LANGUAGE" == "english" || "$LANGUAGE" == "both" ]]; then
-        if [[ -n "$CUADERNILLO" ]]; then
-            python generate_pdf.py "$CUADERNILLO" english all
-        else
-            python generate_pdf.py english all
-        fi
-        echo ""
-    fi
+# Update website markdown files for preview functionality
+echo "📄 Updating website preview data..."
+if [[ -f "../../website/copy-markdown.js" ]]; then
+    cd ../../website
+    node copy-markdown.js
+    cd - > /dev/null
+    echo "✅ Website preview data updated"
 else
-    # Generate specific unit(s)
-    if [[ "$UNIT" == "present-tense" ]]; then
-        if [[ "$LANGUAGE" == "japanese" || "$LANGUAGE" == "both" ]]; then
-            generate_for_unit_and_language "present-tense" "japanese"
-        fi
-        
-        if [[ "$LANGUAGE" == "english" || "$LANGUAGE" == "both" ]]; then
-            generate_for_unit_and_language "present-tense" "english"
-        fi
-    fi
-
-    if [[ "$UNIT" == "past-tense" ]]; then
-        if [[ "$LANGUAGE" == "japanese" || "$LANGUAGE" == "both" ]]; then
-            generate_for_unit_and_language "past-tense" "japanese"
-        fi
-        
-        if [[ "$LANGUAGE" == "english" || "$LANGUAGE" == "both" ]]; then
-            generate_for_unit_and_language "past-tense" "english"
-        fi
-    fi
+    echo "⚠️  Website copy script not found, skipping website update"
 fi
+echo ""
+
+# Generate all PDFs
+echo "📚 Generating Japanese versions..."
+python generate_pdf.py japanese all
+echo ""
+
+echo "📚 Generating English versions..."
+python generate_pdf.py english all
+echo ""
 
 # Deactivate virtual environment
 deactivate


### PR DESCRIPTION
## Summary
- Simplify `generate_pdfs.sh` by removing all command-line options
- Always generate all cuadernillos (1-4) for all units (present-tense, past-tense) in both languages
- Integrate website preview data update into the PDF generation process
- Update documentation to reflect simplified workflow

## Benefits
- **Consistency**: No risk of partial builds or missing combinations
- **Simplicity**: Single command generates everything needed
- **Reliability**: All content stays synchronized between PDFs and website
- **Developer experience**: No complex command-line options to remember

## Changes Made
- Removed argument parsing from `generate_pdfs.sh`
- Script now always generates all combinations automatically
- Added website preview data update to the generation process
- Updated `CLAUDE.md` and `PDF_GENERATION.md` documentation
- Simplified workflow ensures all content stays in sync

## Testing
The script maintains the same output structure and includes automatic verification of PDF page counts.

Close #32